### PR TITLE
Add google map configuration with spec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
---format documentation
 --color
+--require spec_helper

--- a/lib/googlemap.rb
+++ b/lib/googlemap.rb
@@ -1,5 +1,7 @@
 require "googlemap/version"
 
+require "googlemap/config"
+
 module Googlemap
   # Your code goes here...
 end

--- a/lib/googlemap/config.rb
+++ b/lib/googlemap/config.rb
@@ -1,0 +1,20 @@
+require "googlemap/configuration"
+
+module Googlemap
+  module Config
+    def configure
+      if block_given?
+        yield configuration
+      end
+    end
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+  end
+
+  # This exposes the configuration methods in global scope, so
+  # we can directly use those like: `Getstat.configuration`.
+  #
+  extend Config
+end

--- a/lib/googlemap/configuration.rb
+++ b/lib/googlemap/configuration.rb
@@ -1,0 +1,9 @@
+module Googlemap
+  class Configuration
+    attr_accessor :api_host
+
+    def initialize
+      @api_host ||= "maps.googleapis.com/maps/api"
+    end
+  end
+end

--- a/spec/googlemap/config_spec.rb
+++ b/spec/googlemap/config_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+RSpec.describe Googlemap::Config do
+  describe ".configuration" do
+    it "retrieves current client configuration" do
+      api_host = "maps.google.com/api"
+
+      Googlemap.configure do |googlemap_config|
+        googlemap_config.api_host = api_host
+      end
+
+      config = Googlemap.configuration
+
+      expect(config.api_host).to eq(api_host)
+    end
+  end
+end


### PR DESCRIPTION
Based on the google map API, looks like we will need some client specific configuration from the user. So, this commit adds a base configuration which will allow application to specify the client specific configuration.